### PR TITLE
Clean up Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,23 @@
-.PHONY: docs
+.PHONY: coffee docs server
 
-run:
-	python manage.py runserver --settings=local_settings
+# Start the server
+server: venv | local_settings.py
+	. $</bin/activate && python manage.py runserver --settings=local_settings
 
+venv: requirements.txt
+	virtualenv $@
+	. $@/bin/activate && pip install --requirement $< || (rm -r $@ && exit 1)
+
+local_settings.py:
+	cp local_settings.py_default local_settings.py
+
+# Build the documentation
 docs:
 	cd docs && make html
 	@echo "\033[95m\n\nBuild successful! View the docs homepage at docs/_build/html/index.html.\n\033[0m"
 
+# Compile `.coffee` files into `.js` files of the same name. Rerun this command
+# if any files change.
 coffee:
-	coffee -o media/front-end/js -wc media/front-end/coffee
+	coffee --compile media/front-end/coffee --watch --output media/front-end/js
 

--- a/README.rst
+++ b/README.rst
@@ -15,23 +15,17 @@ PennCourseReview is a student-run publication that provides numerical ratings
 and written reviews for undergraduate courses taught at the University of
 Pennsylvania.
 
-Install
+Setup
 ================================================================================
 
-To install ``pcr``, simply::
+To set up your development environment:
 
-    virtualenv venv
-    source venv/bin/activate
-    pip install -r requirements.txt
+1. Copy ``local_settings.py_default`` to ``local_settings.py`` and define
+   ``TOKEN`` and ``DEV_ROOT``, plus anything else you may need.
 
-Next, copy ``local_settings.py_default`` to ``local_settings.py`` and define
-``TOKEN`` and ``DEV_ROOT``, plus anything else you may need.
+2. Start the server locally, via::
 
-At this point, if you are editing on the server things should just work.
-
-If you are editing locally, you can run the server as follows::
-
-    make run
+    make server
 
 Documentation
 ================================================================================


### PR DESCRIPTION
This adds some documentation, changes `make run` to `make server`
(following `rails server`), and simplifies the README. Also, since `make
server` now specifies a dependency on `env`, a virtualenv will be
created automatically if one does not already exist when the developer
goes to start the server.
