### PR TITLE
Added capitalization function for instructor pages

### DIFF
--- a/apps/pcr_detail/templates/pcr_detail/templatetags/scoretable/instructor.html
+++ b/apps/pcr_detail/templates/pcr_detail/templatetags/scoretable/instructor.html
@@ -23,7 +23,7 @@
       </td>
         {% with reviews=group.list %}
       <td class="col_name">
-          {{reviews|sectionname|title}}
+          {{reviews|sectionname|title|capitalize_improved}}
       </td>
           {% with reviews|recent as recents %}
             {% for attribute in reviews|columns %}


### PR DESCRIPTION
Before
![roman old](https://cloud.githubusercontent.com/assets/4293144/10554593/eb40e164-7432-11e5-8a28-9e150dd800f2.png)

After
![roman new](https://cloud.githubusercontent.com/assets/4293144/10554596/edef8988-7432-11e5-8413-ff9c342159f2.png)

Fixes #166 
