### PR TITLE
Fix for multiline issue on searchbar

### DIFF
--- a/media/front-end/css/searchbox.css
+++ b/media/front-end/css/searchbox.css
@@ -69,7 +69,7 @@
   font-weight: 400;
   font-size: 30px;
   margin: 0px 0px 0px 9px;
-  width: 208px;
+  min-width: 208px;
 
 }
 .ui-menu-item-desc {


### PR DESCRIPTION
Before:
![before sb](https://cloud.githubusercontent.com/assets/4293144/10706219/0e126fe8-79b3-11e5-8707-065e74017680.png)

After:
![after sb](https://cloud.githubusercontent.com/assets/4293144/10706218/0b4f0154-79b3-11e5-9e4f-c680092648f7.png)

Fixes #173 

@adelq 
