### PR TITLE
Fix multiline professor names (alignment is the same for single-line …

### DIFF
--- a/media/front-end/css/base.css
+++ b/media/front-end/css/base.css
@@ -174,7 +174,7 @@ input {
 /***** BANNER *****/
 
 .instructor {
-  margin-top: 90px;
+  margin-top: 70px;
 }
 
 #banner {
@@ -192,7 +192,7 @@ input {
   font-family: 'BebasNeueRegular';
   font-size:60px;
   color:#ffffff;
-  line-height: 35%;
+  line-height: 100%;
   padding-bottom: 15px;
 }
 #banner-info .subtitle {


### PR DESCRIPTION
Shortened the top css property and increased line-height. This makes it so the top aligns the same, but for professors with names over one line, it does not overlap.