### PR TITLE
Various on dept page

### DIFF
--- a/apps/pcr_detail/templates/pcr_detail/templatetags/scoretable/department.html
+++ b/apps/pcr_detail/templates/pcr_detail/templatetags/scoretable/department.html
@@ -23,9 +23,9 @@
         {% with all_cols=reviews|columns reviews=group.list %}
       <td class="col_name">
           {{coursehistory|subtitle|title|capitalize_improved|slice:"0:60"}}
-	  {% if coursehistory|subtitle|title|capitalize_improved|length > 60 %}
-	    ...
-	  {% endif %}
+          {% if coursehistory|subtitle|title|capitalize_improved|length > 60 %}
+            ...
+          {% endif %}
       </td>
           {% with reviews|recent as recents %}
             {% for attribute in all_cols %}


### PR DESCRIPTION
Jason and I got an email of someone upset that the dept. page doesn't shows various and it isnt helpful. So I basically replaced it with the Recent Example. This is somewhat of an opinionated thing, but Jason, Tiff and I all like it.