### PR TITLE
Recent example to title

### DIFF
--- a/apps/pcr_detail/templatetags/prettify.py
+++ b/apps/pcr_detail/templatetags/prettify.py
@@ -104,7 +104,6 @@ def attributes(reviews):
 @register.filter(name="sectionname")
 def sectionname(reviews):
   names = set(review.section.name.strip() for review in reviews)
-  print(names)
   if len(names) > 1:
     return "Various"
   else:


### PR DESCRIPTION
Tiffany did not like the term Recent Example used in PCR. Not a huge fan myself. We decided on Recent Title instead. Again, another opinionated change, but Jason and I agree. 