### PR TITLE
Fix overlap issue

### DIFF
--- a/media/front-end/css/searchbox.css
+++ b/media/front-end/css/searchbox.css
@@ -133,3 +133,7 @@
 .ui-autocomplete-category p {
 
 }
+
+#results_top {
+    z-index: 10;
+}


### PR DESCRIPTION
Fixes bug #245.

The `z-index` css on the results box seems to be generated by the jQuery UI library, so it seems like the best solution is to set the `z-index` of the parent element.