### PR TITLE
Update wsgi handler

### DIFF
--- a/django.wsgi
+++ b/django.wsgi
@@ -8,5 +8,5 @@ from settings import PROJECT_PATH
 sys.path.append(PROJECT_PATH)
 os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'
 
-import django.core.handlers.wsgi
-application = django.core.handlers.wsgi.WSGIHandler()
+from django.core.wsgi import get_wsgi_application
+application = get_wsgi_application()


### PR DESCRIPTION
The method for the wsgi handler was updated in some Django version, and the old one doesn't work.