### PR TITLE
Update path for logging out

### DIFF
--- a/apps/pcr_detail/templates/pcr_detail/templatetags/links.html
+++ b/apps/pcr_detail/templates/pcr_detail/templatetags/links.html
@@ -4,5 +4,5 @@
 <span>|</span>
 <a href="https://docs.google.com/spreadsheet/viewform?formkey=dFNZYW92cFM1YnpKUzlLcXRDZVQ4VGc6MQ#gid=0faq">Feedback</a>
 <span>|</span>
-<a href="https://weblogin.pennkey.upenn.edu/logout">Logout</a>
+<a href="{% url "logout" %}">Logout</a>
 

--- a/apps/static/urls.py
+++ b/apps/static/urls.py
@@ -4,6 +4,7 @@ from . import views
 
 
 urlpatterns = [
+    url(r'logout', views.logout, name="logout"),
     url(r'about', views.about, name="about"),
     url(r'cart', views.cart, name="cart"),
     url(r'faq', views.faq, name="faq"),

--- a/apps/static/views.py
+++ b/apps/static/views.py
@@ -1,4 +1,4 @@
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from django.http import HttpResponse
 from django.conf import settings
 import mimetypes
@@ -24,6 +24,10 @@ def faq(request):
 
 def cart(request):
     return static(request, "cart")
+
+
+def logout(request):
+    return redirect("https://idp.pennkey.upenn.edu/logout")
 
 
 def proxy(request, path):


### PR DESCRIPTION
The `weblogin` path does not clear the Shibboleth session correctly, and the `idp` path must be used.

This change also first redirects to `/logout` before the Penn logout site, which gives Nginx a chance to intercept the logout request and clear the cookies on our side.