### PR TITLE
Added semester to section short JSON

### DIFF
--- a/api/courses/models.py
+++ b/api/courses/models.py
@@ -565,6 +565,7 @@ class Section(models.Model):
             'name': self.name,
             'sectionnum': "%03d" % self.sectionnum,
             'path': self.get_absolute_url(),
+            'semester': self.course.semester.code(),
         }
 
     def toJSON(self):

--- a/api/courses/views.py
+++ b/api/courses/views.py
@@ -325,7 +325,12 @@ def dept_main(request, dept_code):
 
 def dept_reviews(request, dept_code):
     reviews = Review.objects.filter(
-        section__course__alias__department__code=dept_code)
+        section__course__alias__department__code=dept_code
+    ).prefetch_related('section', 
+                       'instructor', 
+                       'reviewbit_set')\
+                           .prefetch_related('section__course')\
+                           .prefetch_related('section__course__primary_alias')
     return JSON({RSRCS: [r.toJSON() for r in reviews]})
 
 

--- a/api/courses/views.py
+++ b/api/courses/views.py
@@ -326,8 +326,8 @@ def dept_main(request, dept_code):
 def dept_reviews(request, dept_code):
     reviews = Review.objects.filter(
         section__course__alias__department__code=dept_code
-    ).prefetch_related('section', 
-                       'instructor', 
+    ).prefetch_related('section',
+                       'instructor',
                        'reviewbit_set')\
                            .prefetch_related('section__course')\
                            .prefetch_related('section__course__primary_alias')


### PR DESCRIPTION
This PR adds semester info to the short JSON for sections in the `v1` API endpoints. The logic behind this is that to properly identify a specific section (or to identify a course for that matter), you need both its course code AND its semester.

Additionally, I added some [`prefetch_related`](https://docs.djangoproject.com/en/2.1/ref/models/querysets/#prefetch-related) calls on the department reviews view. This has seemed to reduce latency from 70+ seconds for all CIS reviews down to ~30 seconds.