### PR TITLE
add endpoint to get all reviews for a semester

### DIFF
--- a/api/courses/urls.py
+++ b/api/courses/urls.py
@@ -35,6 +35,7 @@ urlpatterns = [
     # Semesters
     url(r"^semesters/?$", views.semesters),
     url(r"^semesters/(?P<semester_code>[^/]+)/?$", views.semester_main, name="semester"),
+    url(f"^semesters/(?P<semester_code>[^/]+)/reviews/", views.semester_reviews, name="semrevs"),
     url(r"^semesters/(?P<semester_code>[^/]+)/(?P<dept_code>[^/]+)/?$", views.semester_dept, name="semdept"),
 
     # Buildings

--- a/api/courses/views.py
+++ b/api/courses/views.py
@@ -126,6 +126,14 @@ def semester_dept(request, semester_code, dept_code):
     return JSON(dept.toJSON())
 
 
+def semester_reviews(request, semester_code):
+    sem = semesterFromCode(semester_code)
+    reviews = Review.objects.filter(
+        section__course__semester=sem
+    ).prefetch_related('section', 'instructor', 'reviewbit_set', 'section__course', 'section__course__primary_alias')
+    return JSON({RSRCS: [r.toJSON() for r in reviews]})
+
+
 def instructors(request):
     if not request.consumer.access_pcr:
         # This method is only available to those with review data access.

--- a/api/courses/views.py
+++ b/api/courses/views.py
@@ -127,6 +127,9 @@ def semester_dept(request, semester_code, dept_code):
 
 
 def semester_reviews(request, semester_code):
+    if not request.consumer.access_pcr:
+        # This method is only available to those with review data access.
+        raise API404("This is not the database dump you are looking for.")
     sem = semesterFromCode(semester_code)
     reviews = Review.objects.filter(
         section__course__semester=sem


### PR DESCRIPTION
This PR adds an endpoint to the v1 API to get all reviews for a given semester. It'll be super useful for PCP, so that we can sync new reviews on a per-semester basis.